### PR TITLE
fixed: Filter out 'Note Added' from inline history entries

### DIFF
--- a/InlineHistory/InlineHistory.php
+++ b/InlineHistory/InlineHistory.php
@@ -211,7 +211,7 @@ class InlineHistoryPlugin extends MantisPlugin {
 				'</span>',
 				'<span class="IHright">',
 					'<span class="IHfield">', string_display( $t_item['note'] ), '</span>',
-					'<span class="IHchange">', string_display_line_links( $t_item['change'] ), '</span>',
+					'<span class="IHchange">', $t_item['change'], '</span>',
 				'</span></td></tr>';
 
 			$t_last_date = $t_item['date'];

--- a/InlineHistory/InlineHistory.php
+++ b/InlineHistory/InlineHistory.php
@@ -283,5 +283,5 @@ class InlineHistoryPlugin extends MantisPlugin {
  * @return True if entry not "Note Added: xyz"
  */
 function InlineHistory_Filter_Entries( $p_entry ) {
-	return (stristr($p_entry['note'], 'Note Added:') != $p_entry['note']);
+	return (stristr($p_entry['note'], lang_get( 'bugnote_added' ).':') != $p_entry['note']);
 }

--- a/InlineHistory/InlineHistory.php
+++ b/InlineHistory/InlineHistory.php
@@ -237,6 +237,7 @@ class InlineHistoryPlugin extends MantisPlugin {
 
 			if ( $this->order ) {
 				while( $t_count > 0 &&
+					is_array( $this->history[0] ) &&
 					$this->history[0]['date'] < $t_note_time ) {
 
 					$t_entries[] = array_shift( $this->history );


### PR DESCRIPTION
(introduced in 00512f37e2ed9ba3f34bd0d43624fd9b2bfd834b) does not respect user language
