### PR TITLE
Infinite loop when there is only one history entry

### DIFF
--- a/InlineHistory/InlineHistory.php
+++ b/InlineHistory/InlineHistory.php
@@ -228,6 +228,24 @@ class InlineHistoryPlugin extends MantisPlugin {
 			echo '<tr class="spacer"><td colspan="2"></td></tr>';
 		}
 	}
+	
+	/**
+	* Check if the note time is before the current history items
+	* or if we need to look further.
+	* @param date Time of next note to be displayed
+	* @return true if current history item needs to be displayed before the next note
+	*/
+	private function need_next( $p_note_time ) {
+		if ( !isset( $this->history[0] ) ) {
+			return false;
+		}
+		$t_need_next = $this->history[0]['date'] < $p_note_time;
+		if ( $this->order ) {
+			return $t_need_next;
+		} else {
+			return !$t_need_next;
+		}
+	}
 
 	/**
 	 * Generate a list of remaining history entries that occurred before
@@ -239,14 +257,9 @@ class InlineHistoryPlugin extends MantisPlugin {
 		if ( $p_bugnote_id >= 0 && isset( $this->bugnote_times[ $p_bugnote_id ] ) ) {
 			$t_note_time = $this->bugnote_times[ $p_bugnote_id ];
 			$t_entries = array();
-			if ( $this->order ) {
-				while( $this->history[0] !== NULL && $this->history[0]['date'] < $t_note_time ) {
-					$t_entries[] = array_shift( $this->history );
-				}
-			} else {
-				while( $this->history[0] !== NULL && $this->history[0]['date'] >= $t_note_time ) {
-					$t_entries[] = array_shift( $this->history );
-				}
+			# Shift all entries the need to go before the current bugnote
+			while( $this->need_next( $t_note_time ) ) {
+				$t_entries[] = array_shift( $this->history );
 			}
 		} else {
 			$t_entries = $this->history;

--- a/InlineHistory/InlineHistory.php
+++ b/InlineHistory/InlineHistory.php
@@ -240,13 +240,13 @@ class InlineHistoryPlugin extends MantisPlugin {
 					$this->history[0]['date'] < $t_note_time ) {
 
 					$t_entries[] = array_shift( $this->history );
+					$t_count = count( $this->history );
 				}
 			} else {
-				$i = 1;
 				while( $t_count > 0 &&
-					$this->history[$t_count - $i++]['date'] >= $t_note_time ) {
-
+					$this->history[$t_count - 1]['date'] >= $t_note_time ) {
 					$t_entries[] = array_pop( $this->history );
+					$t_count = count( $this->history );
 				}
 			}
 		} else {
@@ -258,7 +258,6 @@ class InlineHistoryPlugin extends MantisPlugin {
 
 			$this->history = array();
 		}
-
 		return $t_entries;
 	}
 


### PR DESCRIPTION
Originally reported here http://www.mantisbt.org/bugs/view.php?id=16066

When the plugin displays the history in ascending order and the last bugnote is more recent than all history items the next_entry function, it will go into an endless loop crashing the server.

PHP Fatal error: Allowed memory size of 134217728 bytes exhausted (tried to allocate 71 bytes) in /var/www/mantisbt/core/lang_api.php on line 212

To reproduce:
1. Issue with some issue history.
2. Add a note
3. Reload page and the page will crash
